### PR TITLE
Add reload function

### DIFF
--- a/Assets/Import Assets/TestLevel/testscene.unity
+++ b/Assets/Import Assets/TestLevel/testscene.unity
@@ -16980,6 +16980,7 @@ MonoBehaviour:
   bulletBox: 150
   coolTime: 0.5
   shootSound: {fileID: 8300000, guid: 8602b7d5cd15c1943a50aa53f171c8cf, type: 3}
+  reloadSound: {fileID: 8300000, guid: 3c5c1d4d7b9307c458890a4beb12e4ae, type: 3}
   muzzleSparkle: {fileID: 1681333724500828, guid: 5530bc1718c8d6248a49109f7d90a695,
     type: 2}
   hitSparkle: {fileID: 1556301465489146, guid: eeb94513c6bc0dc43a65f974c838c4b1, type: 2}
@@ -16993,7 +16994,7 @@ AudioSource:
   m_Enabled: 1
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 8300000, guid: 8602b7d5cd15c1943a50aa53f171c8cf, type: 3}
+  m_audioClip: {fileID: 0}
   m_PlayOnAwake: 0
   m_Volume: 1
   m_Pitch: 1

--- a/Assets/Scripts/Gun.cs
+++ b/Assets/Scripts/Gun.cs
@@ -7,11 +7,15 @@ public class Gun : MonoBehaviour {
 	public int bullet;
 	public int bulletBox;
 	int residualBullet;
+	int reloadBullet;
 
 	[SerializeField] float coolTime;
 	float resetCoolTime;
 
+	bool isReload = false;
+
 	[SerializeField] AudioClip shootSound;
+	[SerializeField] AudioClip reloadSound;
 	AudioSource audioSource;
 
 	[SerializeField] GameObject muzzleSparkle;
@@ -31,12 +35,20 @@ public class Gun : MonoBehaviour {
 	// Update is called once per frame
 	void Update () {
 		coolTime -= Time.deltaTime;
+		reloadBullet = bullet - residualBullet;
 
 		if (Input.GetMouseButton(0) && residualBullet != 0) {
-			if (coolTime <= 0f){
+			if (coolTime <= 0f && isReload == false){
 				Shoot();
 			}
 		}
+
+		if (Input.GetKeyDown (KeyCode.R) && residualBullet < bullet && bulletBox > 0) {
+			isReload = true;
+			Reload ();
+			StartCoroutine ("WaitForReload");
+		}
+
 	}
 
 	void Shoot () {
@@ -55,5 +67,18 @@ public class Gun : MonoBehaviour {
 			Destroy (hitEffect, .2f);
 		}
 	}
+
+
+	 void Reload(){
+        audioSource.PlayOneShot (reloadSound);
+        residualBullet += reloadBullet;
+        bulletBox -= reloadBullet;
+    }
+
+	IEnumerator WaitForReload(){
+		yield return new WaitForSeconds (3);
+		isReload = false;
+	}
+
 
 }


### PR DESCRIPTION
# What
・リロード機能の追加
　　装弾数が装弾上限数より下回っているときに「R」を押すとリロード
　　　弾薬数の設定
　　　弾薬上限数の設定
　　　弾倉の設定
　　　リロード音の設定

# Why
・弾薬数に制限をつけるため

Hierarchy
https://gyazo.com/33a975476c60a95cdebfeb1a1189443b
Game
https://gyazo.com/736e11080507a72ed9157c896ca6a82d